### PR TITLE
fix the random occupying process

### DIFF
--- a/leath_algorithm.py
+++ b/leath_algorithm.py
@@ -115,9 +115,13 @@ class PercCluster():
     def make_step(self):
         if(len(self.current_nearest_neighbors) == 0):
             return 0
-
+        
+        #random_neighbors = random.sample(self.current_nearest_neighbors,k=round(self.p * len(self.current_nearest_neighbors)))
+        
+        # Randomly and independently occupy the current_nearest_neighbors grids, 
+        # each grid has a likelyhood of self.p for being occupied
         random_neighbors = random.sample(self.current_nearest_neighbors,
-                                         k=round(self.p * len(self.current_nearest_neighbors)))
+                                         k= sum(np.random.binomial(1, self.p, len(self.current_nearest_neighbors))) )
 
         self.prohibit_nodes(self.current_nearest_neighbors.difference(random_neighbors))
         self.occupy_nodes(random_neighbors)

--- a/leath_algorithm.py
+++ b/leath_algorithm.py
@@ -116,13 +116,14 @@ class PercCluster():
         if(len(self.current_nearest_neighbors) == 0):
             return 0
         
+        # this is wrong here, as long as there is occupiable cells in the list, there will be round(self.p * len(self.current_nearest_neighbors)) cells converted, 
+        # however, it is possible that when there are occupiable cells, the structure stops growing as every cell has a possibility of being not occupied.
         #random_neighbors = random.sample(self.current_nearest_neighbors,k=round(self.p * len(self.current_nearest_neighbors)))
-        
-        # Randomly and independently occupy the current_nearest_neighbors grids, 
-        # each grid has a likelyhood of self.p for being occupied
+        # my solution, it is generally a process of n independent Bernoulli trials ~ B(n,p),
+        # Randomly and independently occupy the current_nearest_neighbors grids, each grid has a likelyhood of self.p for being occupied
         random_neighbors = random.sample(self.current_nearest_neighbors,
                                          k= sum(np.random.binomial(1, self.p, len(self.current_nearest_neighbors))) )
-
+        
         self.prohibit_nodes(self.current_nearest_neighbors.difference(random_neighbors))
         self.occupy_nodes(random_neighbors)
 


### PR DESCRIPTION
It is not correct to use `random_neighbors = random.sample(self.current_nearest_neighbors,k=round(self.p * len(self.current_nearest_neighbors)))`, which means as long as there is occupiable cells in the list, there will be `round(self.p * len(self.current_nearest_neighbors))` cells converted. However, it is possible that when there are occupiable cells, the structure stops growing as every cell has a possibility of being not occupied.

my solution, it is generally a process of n independent Bernoulli trials ~ _B(n,p)_, randomly and independently occupy the `current_nearest_neighbors` grids, each grid has a likelihood of `self.p` for being occupied, so this can be:
 `random_neighbors = random.sample(self.current_nearest_neighbors, k= sum(np.random.binomial(1, self.p, len(self.current_nearest_neighbors))) )`.